### PR TITLE
MuchThread#timeout

### DIFF
--- a/lib/much-timeout.rb
+++ b/lib/much-timeout.rb
@@ -1,4 +1,42 @@
+require 'thread'
 require "much-timeout/version"
 
 module MuchTimeout
+
+  TimeoutError = Class.new(Interrupt)
+
+  PIPE_SIGNAL = '.'
+
+  def self.timeout(seconds, klass = nil, &block)
+    if seconds.nil?
+      raise ArgumentError, 'please specify a non-nil seconds value'
+    end
+    if !seconds.kind_of?(::Numeric)
+      raise ArgumentError, "please specify a numeric seconds value "\
+                           "(`#{seconds.inspect}` was given)"
+    end
+    exception_klass = klass || TimeoutError
+    reader, writer  = IO.pipe
+
+    begin
+      block_thread ||= Thread.new do
+        begin
+          block.call
+        ensure
+          writer.write_nonblock(PIPE_SIGNAL) rescue false
+        end
+      end
+      if !!::IO.select([reader], nil, nil, seconds)
+        block_thread.join
+      else
+        block_thread.raise exception_klass
+        block_thread.join
+      end
+      block_thread.value
+    ensure
+      reader.close rescue false
+      writer.close rescue false
+    end
+  end
+
 end

--- a/test/unit/much-timeout_tests.rb
+++ b/test/unit/much-timeout_tests.rb
@@ -1,0 +1,90 @@
+require 'assert'
+require 'much-timeout'
+
+module MuchTimeout
+
+  class UnitTests < Assert::Context
+    desc "MuchTimeout"
+    setup do
+      @module = MuchTimeout
+    end
+    subject{ @module }
+
+    should have_imeths :timeout
+
+    should "know its TimeoutError" do
+      assert_true subject::TimeoutError < Interrupt
+    end
+
+    should "know its pipe signal" do
+      assert_equal '.', subject::PIPE_SIGNAL
+    end
+
+  end
+
+  class TimeoutSetupTests < UnitTests
+    setup do
+      @mutex    = Mutex.new
+      @cond_var = ConditionVariable.new
+
+      @seconds = 0.01
+    end
+    teardown do
+      @cond_var.broadcast
+    end
+  end
+
+  class TimeoutTests < TimeoutSetupTests
+    desc "`timeout` method"
+
+    should "interrupt and raise if the block takes too long to run" do
+      assert_raises(TimeoutError) do
+        subject.timeout(@seconds) do
+          @mutex.synchronize{ @cond_var.wait(@mutex) }
+        end
+      end
+    end
+
+    should "interrupt and raise if a custom exception is given and block times out" do
+      exception = Class.new(RuntimeError)
+
+      assert_raises(exception) do
+        subject.timeout(@seconds, exception) do
+          @mutex.synchronize{ @cond_var.wait(@mutex) }
+        end
+      end
+    end
+
+    should "not interrupt and return the block's return value if there is no timeout" do
+      exp = Factory.string
+      val = nil
+
+      assert_nothing_raised do
+        val = subject.timeout(@seconds){ exp }
+      end
+      assert_equal exp, val
+    end
+
+    should "raise any exception that the block raises" do
+      exception = Class.new(RuntimeError)
+
+      assert_raises(exception) do
+        subject.timeout(@seconds){ raise exception }
+      end
+    end
+
+    should "complain if given a nil seconds value" do
+      assert_raises(ArgumentError) do
+        subject.timeout(nil){ }
+      end
+    end
+
+    should "complain if given a non-numeric seconds value" do
+      assert_raises(ArgumentError) do
+        subject.timeout(Factory.string){ }
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
This implements the main `timeout` method.  This method takes a
seconds value and optional custom exception and a block.  It will
raise the custom exception (or `MuchTimeout::TimeoutError`if no
custom exception given) if calling the block takes more than
the given amount of seconds.

A few notes on this:
- this uses `IO.select` on an internal pipe to get accurate
  timeouts and to avoid having to `sleep`
- the block runs in a seperate thread from the main thread.  This
  is so we can safely raise in the block thread to interrupt and
  not affect the main thread.
- `timeout` requires a non-nil, numeric seconds value.  The idea
  here is that we want to protect from unintended side-effects or
  strange exceptions if giving `IO.select` non standard timeout
  values.
- `rescue false` on any pipe interactions to prevent errors from
  edge-case pipe scenarios from leaking unintended exceptions
- ensure we close any pipes to prevent any side-effects from
  unintentionally leaving file descriptors open

This is the base logic that the rest of the API will be built on.
In a coming effort, I'll implement the rest of the API.

@jcredding ready for review.  Note: I couldn't test closing the file descriptors b/c when I stubbed IO.pipe it caused Assert to just sit there and stare at me when I ran test suite.  LOL.
