### PR TITLE
build out the remaining api for the initial design

### DIFF
--- a/lib/much-timeout.rb
+++ b/lib/much-timeout.rb
@@ -12,7 +12,7 @@ module MuchTimeout
       raise ArgumentError, 'please specify a non-nil seconds value'
     end
     if !seconds.kind_of?(::Numeric)
-      raise ArgumentError, "please specify a numeric seconds value "\
+      raise ArgumentError, "please specify a numeric seconds value " \
                            "(`#{seconds.inspect}` was given)"
     end
     exception_klass = klass || TimeoutError
@@ -36,6 +36,52 @@ module MuchTimeout
     ensure
       reader.close rescue false
       writer.close rescue false
+    end
+  end
+
+  def self.optional_timeout(seconds, klass = nil, &block)
+    if !seconds.nil?
+      self.timeout(seconds, klass, &block)
+    else
+      block.call
+    end
+  end
+
+  def self.just_timeout(seconds, args)
+    args ||= {}
+    if args[:do].nil?
+      raise ArgumentError, 'you need to specify a :do block arg to call'
+    end
+    if !args[:do].kind_of?(::Proc)
+      raise ArgumentError, "you need pass a Proc as the :do arg " \
+                           "(`#{args[:do].inspect}` was given)"
+    end
+    if !args[:on_timeout].nil? && !args[:on_timeout].kind_of?(::Proc)
+      raise ArgumentError, "you need pass a Proc as the :on_timeout arg " \
+                           "(`#{args[:on_timeout].inspect}` was given)"
+    end
+
+    begin
+      self.timeout(seconds, &args[:do])
+    rescue TimeoutError
+      (args[:on_timeout] || proc{ }).call
+    end
+  end
+
+  def self.just_optional_timeout(seconds, args)
+    args ||= {}
+    if args[:do].nil?
+      raise ArgumentError, 'you need to specify a :do block arg to call'
+    end
+    if !args[:do].kind_of?(::Proc)
+      raise ArgumentError, "you need pass a Proc as the :do arg " \
+                           "(`#{args[:do].inspect}` was given)"
+    end
+
+    if !seconds.nil?
+      self.just_timeout(seconds, args)
+    else
+      args[:do].call
     end
   end
 

--- a/test/unit/much-timeout_tests.rb
+++ b/test/unit/much-timeout_tests.rb
@@ -10,7 +10,8 @@ module MuchTimeout
     end
     subject{ @module }
 
-    should have_imeths :timeout
+    should have_imeths :timeout, :optional_timeout
+    should have_imeths :just_timeout, :just_optional_timeout
 
     should "know its TimeoutError" do
       assert_true subject::TimeoutError < Interrupt
@@ -24,14 +25,16 @@ module MuchTimeout
 
   class TimeoutSetupTests < UnitTests
     setup do
-      @mutex    = Mutex.new
-      @cond_var = ConditionVariable.new
-
-      @seconds = 0.01
+      @mutex      = Mutex.new
+      @cond_var   = ConditionVariable.new
+      @seconds    = 0.01
+      @exception  = Class.new(RuntimeError)
+      @return_val = Factory.string
     end
     teardown do
       @cond_var.broadcast
     end
+
   end
 
   class TimeoutTests < TimeoutSetupTests
@@ -46,30 +49,24 @@ module MuchTimeout
     end
 
     should "interrupt and raise if a custom exception is given and block times out" do
-      exception = Class.new(RuntimeError)
-
-      assert_raises(exception) do
-        subject.timeout(@seconds, exception) do
+      assert_raises(@exception) do
+        subject.timeout(@seconds, @exception) do
           @mutex.synchronize{ @cond_var.wait(@mutex) }
         end
       end
     end
 
     should "not interrupt and return the block's return value if there is no timeout" do
-      exp = Factory.string
       val = nil
-
       assert_nothing_raised do
-        val = subject.timeout(@seconds){ exp }
+        val = subject.timeout(@seconds){ @return_val }
       end
-      assert_equal exp, val
+      assert_equal @return_val, val
     end
 
     should "raise any exception that the block raises" do
-      exception = Class.new(RuntimeError)
-
-      assert_raises(exception) do
-        subject.timeout(@seconds){ raise exception }
+      assert_raises(@exception) do
+        subject.timeout(@seconds){ raise @exception }
       end
     end
 
@@ -82,6 +79,241 @@ module MuchTimeout
     should "complain if given a non-numeric seconds value" do
       assert_raises(ArgumentError) do
         subject.timeout(Factory.string){ }
+      end
+    end
+
+  end
+
+  class OptionalTimeoutTests < TimeoutSetupTests
+    desc "`optional_timeout` method"
+
+    should "call `timeout` with any given args if seconds is not nil" do
+      # this repeats the relevent tests from the TimeoutTests above
+
+      assert_raises(TimeoutError) do
+        subject.optional_timeout(@seconds) do
+          @mutex.synchronize{ @cond_var.wait(@mutex) }
+        end
+      end
+
+      assert_raises(@exception) do
+        subject.optional_timeout(@seconds, @exception) do
+          @mutex.synchronize{ @cond_var.wait(@mutex) }
+        end
+      end
+
+      val = nil
+      assert_nothing_raised do
+        val = subject.optional_timeout(@seconds){ @return_val }
+      end
+      assert_equal @return_val, val
+
+      assert_raises(@exception) do
+        subject.optional_timeout(@seconds){ raise @exception }
+      end
+
+      assert_raises(ArgumentError) do
+        subject.optional_timeout(Factory.string){ }
+      end
+    end
+
+    should "call the given block directly if seconds is nil" do
+      val = nil
+      assert_nothing_raised do
+        val = subject.optional_timeout(nil){ sleep @seconds; @return_val }
+      end
+      assert_equal @return_val, val
+
+      assert_raises(@exception) do
+        subject.optional_timeout(nil){ raise @exception }
+      end
+    end
+
+  end
+
+  class JustTimeoutTests < TimeoutSetupTests
+    desc "`just_timeout` method"
+    setup do
+      @val_set = nil
+    end
+
+    should "call `timeout` with the given seconds and :do arg" do
+      # this repeats the relevent tests from the TimeoutTests above
+
+      assert_nothing_raised do
+        subject.just_timeout(@seconds, :do => proc{
+          @mutex.synchronize{ @cond_var.wait(@mutex) }
+          @val_set = Factory.string
+        })
+      end
+      assert_nil @val_set
+
+      val = nil
+      assert_nothing_raised do
+        val = subject.just_timeout(@seconds, :do => proc{ @return_val })
+      end
+      assert_equal @return_val, val
+
+      assert_raises(@exception) do
+        subject.just_timeout(@seconds, :do => proc{ raise @exception })
+      end
+
+      assert_raises(ArgumentError) do
+        subject.just_timeout(nil, :do => proc{ })
+      end
+
+      assert_raises(ArgumentError) do
+        subject.just_timeout(Factory.string, :do => proc{ })
+      end
+    end
+
+    should "call any given :on_timeout arg if a timeout occurs" do
+      exp = Factory.string
+      assert_nothing_raised do
+        subject.just_timeout(@seconds, {
+          :do => proc{
+            @mutex.synchronize{ @cond_var.wait(@mutex) }
+          },
+          :on_timeout => proc{ @val_set = exp }
+        })
+      end
+      assert_equal exp, @val_set
+
+      @val_set = val = nil
+      assert_nothing_raised do
+        val = subject.just_timeout(@seconds, {
+          :do         => proc{ @return_val },
+          :on_timeout => proc{ @val_set = exp }
+        })
+      end
+      assert_equal @return_val, val
+      assert_nil @val_set
+    end
+
+    should "complain if not given a :do arg" do
+      assert_raises(ArgumentError) do
+        subject.just_timeout(@seconds){ }
+      end
+      assert_raises(ArgumentError) do
+        subject.just_timeout(@seconds, :do => nil)
+      end
+    end
+
+    should "complain if given a non-proc :do arg" do
+      assert_raises(ArgumentError) do
+        subject.just_timeout(@seconds, :do => Factory.string)
+      end
+    end
+
+    should "complain if given a non-proc :on_timeout arg" do
+      assert_raises(ArgumentError) do
+        subject.just_timeout(@seconds, {
+          :do         => proc{ },
+          :on_timeout => Factory.string
+        })
+      end
+    end
+
+  end
+
+  class JustOptionalTimeoutTests < TimeoutSetupTests
+    desc "`just_optional_timeout` method"
+    setup do
+      @val_set = nil
+    end
+
+    should "call `optional_timeout` with the given seconds and :do arg" do
+      # this repeats the relevent tests from the JustTimeoutTests above
+
+      assert_nothing_raised do
+        subject.just_optional_timeout(@seconds, :do => proc{
+          @mutex.synchronize{ @cond_var.wait(@mutex) }
+          @val_set = Factory.string
+        })
+      end
+      assert_nil @val_set
+
+      val = nil
+      assert_nothing_raised do
+        val = subject.just_optional_timeout(@seconds, :do => proc{ @return_val })
+      end
+      assert_equal @return_val, val
+
+      assert_raises(@exception) do
+        subject.just_optional_timeout(@seconds, :do => proc{ raise @exception })
+      end
+
+      assert_raises(ArgumentError) do
+        subject.just_optional_timeout(Factory.string, :do => proc{ })
+      end
+
+      exp = Factory.string
+      assert_nothing_raised do
+        subject.just_optional_timeout(@seconds, {
+          :do => proc{
+            @mutex.synchronize{ @cond_var.wait(@mutex) }
+          },
+          :on_timeout => proc{ @val_set = exp }
+        })
+      end
+      assert_equal exp, @val_set
+
+      @val_set = val = nil
+      assert_nothing_raised do
+        val = subject.just_optional_timeout(@seconds, {
+          :do         => proc{ @return_val },
+          :on_timeout => proc{ @val_set = exp }
+        })
+      end
+      assert_equal @return_val, val
+      assert_nil @val_set
+
+      assert_raises(ArgumentError) do
+        subject.just_optional_timeout(@seconds){ }
+      end
+      assert_raises(ArgumentError) do
+        subject.just_optional_timeout(@seconds, :do => nil)
+      end
+
+      assert_raises(ArgumentError) do
+        subject.just_optional_timeout(@seconds, :do => Factory.string)
+      end
+
+      assert_raises(ArgumentError) do
+        subject.just_optional_timeout(@seconds, {
+          :do         => proc{ },
+          :on_timeout => Factory.string
+        })
+      end
+    end
+
+    should "call the given :do arg directly if seconds is nil" do
+      val = nil
+      assert_nothing_raised do
+        val = subject.just_optional_timeout(nil, :do => proc{
+          sleep @seconds
+          @return_val
+        })
+      end
+      assert_equal @return_val, val
+
+      assert_raises(@exception) do
+        subject.just_optional_timeout(nil, :do => proc{ raise @exception })
+      end
+    end
+
+    should "complain if not given a :do arg" do
+      assert_raises(ArgumentError) do
+        subject.just_optional_timeout([@seconds, nil].sample){ }
+      end
+      assert_raises(ArgumentError) do
+        subject.just_optional_timeout([@seconds, nil].sample, :do => nil)
+      end
+    end
+
+    should "complain if given a non-proc :do arg" do
+      assert_raises(ArgumentError) do
+        subject.just_optional_timeout([@seconds, nil].sample, :do => Factory.string)
       end
     end
 


### PR DESCRIPTION
This adds the 3 additional api methods: `optional_timeout`,
`just_timeout` and `just_optional_timeout`.  These methods each
provide special behavior in addition to the base `timeout` logic.

`optional_timeout` allows passing `nil` as the seconds value to
disable any timeout.  This is a thin wrapper to `timeout` that
saves the developer a manual `if secs.nil?` conditional.

`just_timeout` does the same logic as `timeout` except that it
only interrupts the block and never raises an exception.  Its
signature is different: you pass the block as the value of the
`:do` key in hash args.  You can optionally pass an `:on_timeout`
block to run custom logic when timeouts occur.

`just_optional_timeout` combines the signature and behavior of
`just_timeout` with the `nil` seconds behavior of `optional_timeout`.
It behaves as you would expect.

Note: I chose to not stub the nested api calls and instead layer
on (ie repeat) the tests of the nested calls.  I chose this to
not only _actually_ test the intended behavior of each method,
but also to not bind the tests to the implementation.

This completes the initial design implementation.

@jcredding ready for review.
